### PR TITLE
Update admin-display.php

### DIFF
--- a/lib/aboss/partials/admin-display.php
+++ b/lib/aboss/partials/admin-display.php
@@ -32,7 +32,7 @@ $account = new ABOSS\Account($apiKey);
     <?php foreach($projects->get() as $project) {
       ?>
       <li><?php echo $project->get('title'); ?></li>
-      <?
+      <?php
     }?>
     </ul>
   </div>


### PR DESCRIPTION
Missing php on the admin display page kills the plugin.